### PR TITLE
Add extra test to highlight and fix `、` based word wrap issue

### DIFF
--- a/src/mikan.js
+++ b/src/mikan.js
@@ -36,7 +36,9 @@
     var prevType = '';
     var prevWord = '';
     words.forEach(function(word) {
-      var token = word.match(periods) || word.match(joshi)
+      var periodToken = word.match(periods);
+      var joshiToken = word.match(joshi);
+      var token = periodToken || joshiToken;
 
       if (word.match(bracketsBegin)) {
         prevType = 'bracketBegin';
@@ -65,9 +67,9 @@
       }
 
       // 単語のあとの文字がひらがななら結合する
-      if (result.length > 1 && token || (prevType === 'keyword' && word.match(/[ぁ-んゝ]+/g))) {
+      if (result.length > 1 && token || (prevType === 'keyword' && !prevWord.match(/^[とのに]$/g) && !prevWord.match(periods) && word.match(/[ぁ-んゝ]+/g))) {
         result[result.length - 1] += word;
-        prevType = ''
+        if (!joshiToken) prevType = ''
         prevWord = word;
         return;
       }

--- a/test/mikan-test.js
+++ b/test/mikan-test.js
@@ -62,6 +62,13 @@ test(t => {
 })
 
 test(t => {
+  const source = 'テンプレートを使用しますか、それとも空白の調査から始めますか？'
+  const expected = [ 'テンプレートを', '使用しますか、', 'それとも', '空白の', '調査から', '始めますか？' ]
+  const result = mikan.split(source)
+  t.deepEqual(result, expected)
+})
+
+test(t => {
   const source = '「あれ」でもない、「これ」でもない。'
   const expected =  ['「あれ」', 'でもない、', '「これ」', 'でもない。']
   const result = mikan.split(source)


### PR DESCRIPTION
The following text was line breaking incorrectly for us.

### Input
```
テンプレートを使用しますか、それとも空白の調査から始めますか？
```

### Current Split
```
テンプレートを
使用し
ますか、それとも
空白の
調査から
始めますか？
```

### Correct Split
```
テンプレートを
使用しますか、
それとも
空白の
調査から
始めますか？
```

If there's more cases this would break please let me know, happy to add test cases for them and update the PR.